### PR TITLE
refactor and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#idea
+.idea
+.idea/
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
- избавляем от танцев с  мутексами, юзаем sync.Map
- выкручиваем буфер канал так-как в сокет много спавнится координат
- по той же причине овер-спавна координатами в сокет, юзаем sync.Pool для чуть более дешевого чтения
- избавляемся от json, потому-что на бекенде нам не нужно его как либо мутировать соотвественно нет нужды сериализаровать/десериализаровать. Работаем просто с байтом.
- Избавляемся от лока мапы, даем хендлеру самому рулить чтением и записью в сокет.